### PR TITLE
bug: change name of `string` param to `s`

### DIFF
--- a/internal/provider/empty_function_test.go
+++ b/internal/provider/empty_function_test.go
@@ -96,7 +96,7 @@ output "test" {
   value = provider::assert::empty(local.example)
 }
 				`,
-				ExpectError: regexp.MustCompile(`Invalid value for "string" parameter: argument must not be null`),
+				ExpectError: regexp.MustCompile(`Invalid value for "s" parameter: argument must not be null`),
 			},
 		},
 	})
@@ -116,7 +116,7 @@ output "test" {
   value = provider::assert::empty([])
 }
 				`,
-				ExpectError: regexp.MustCompile(`Invalid value for "string" parameter: string required`),
+				ExpectError: regexp.MustCompile(`Invalid value for "s" parameter: string required`),
 			},
 		},
 	})

--- a/internal/provider/not_empty_function_test.go
+++ b/internal/provider/not_empty_function_test.go
@@ -170,7 +170,7 @@ output "test" {
   value = provider::assert::not_empty(local.example)
 }
 				`,
-				ExpectError: regexp.MustCompile(`Invalid value for "string" parameter: argument must not be null`),
+				ExpectError: regexp.MustCompile(`Invalid value for "s" parameter: argument must not be null`),
 			},
 		},
 	})
@@ -190,7 +190,7 @@ output "test" {
   value = provider::assert::not_empty([])
 }
 				`,
-				ExpectError: regexp.MustCompile(`Invalid value for "string" parameter: string required`),
+				ExpectError: regexp.MustCompile(`Invalid value for "s" parameter: string required`),
 			},
 		},
 	})


### PR DESCRIPTION
- We renamed the param `string` to `s` to improve readability in the signature, but forgot to update the tests