### PR TITLE
improve `not_null` and `null` functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         terraform:
           - '1.8.*'
           - '1.9.*'
+          - '1.10.*'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
@@ -80,6 +81,7 @@ jobs:
         terraform:
           - '1.8.*'
           - '1.9.*'
+          - '1.10.*'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1

--- a/internal/provider/not_null_function.go
+++ b/internal/provider/not_null_function.go
@@ -47,5 +47,19 @@ func (r NotNullFunction) Run(ctx context.Context, req function.RunRequest, resp 
 		return
 	}
 
-	resp.Error = function.ConcatFuncErrors(resp.Result.Set(ctx, !argument.IsNull()))
+	if argument.IsNull() {
+		if err := resp.Result.Set(ctx, false); err == nil {
+			return
+		}
+		return
+	}
+
+	if !argument.IsUnderlyingValueNull() {
+		if err := resp.Result.Set(ctx, true); err == nil {
+			return
+		}
+		return
+	}
+
+	resp.Error = function.ConcatFuncErrors(resp.Result.Set(ctx, false))
 }

--- a/internal/provider/not_null_function.go
+++ b/internal/provider/not_null_function.go
@@ -30,7 +30,7 @@ func (r NotNullFunction) Definition(_ context.Context, _ function.DefinitionRequ
 		Parameters: []function.Parameter{
 			function.DynamicParameter{
 				AllowNullValue:     true,
-				AllowUnknownValues: true,
+				AllowUnknownValues: false,
 				Description:        "The argument to check",
 				Name:               "argument",
 			},

--- a/internal/provider/not_null_function.go
+++ b/internal/provider/not_null_function.go
@@ -48,16 +48,12 @@ func (r NotNullFunction) Run(ctx context.Context, req function.RunRequest, resp 
 	}
 
 	if argument.IsNull() {
-		if err := resp.Result.Set(ctx, false); err == nil {
-			return
-		}
+		resp.Error = resp.Result.Set(ctx, false)
 		return
 	}
 
 	if !argument.IsUnderlyingValueNull() {
-		if err := resp.Result.Set(ctx, true); err == nil {
-			return
-		}
+		resp.Error = resp.Result.Set(ctx, true)
 		return
 	}
 

--- a/internal/provider/not_null_function_test.go
+++ b/internal/provider/not_null_function_test.go
@@ -243,15 +243,15 @@ variable "cidr_block" {
   type        = string
 
   validation {
-    condition = provider::assert::cidr(var.cidr_block)
+    condition     = provider::assert::cidr(var.cidr_block)
     error_message = "CIDR block must be a valid CIDR range."
   }
 
   validation {
     condition = anytrue([
-	  provider::assert::not_null(var.cidr_block), 
-	  provider::assert::not_null(var.ipv4_ipam_pool_id)
-	])
+      provider::assert::not_null(var.cidr_block),
+      provider::assert::not_null(var.ipv4_ipam_pool_id)
+    ])
     error_message = "Exactly one of cidr_block or ipv4_ipam_pool_id must be provided."
   }
 }

--- a/internal/provider/not_null_function_test.go
+++ b/internal/provider/not_null_function_test.go
@@ -244,7 +244,6 @@ variable "example_value_b" {
     condition = anytrue([
       provider::assert::not_null(var.example_value_a),
       provider::assert::not_null(var.example_value_b)
-
     ])
     error_message = "At least one of example_value_a or example_value_b must be provided."
   }

--- a/internal/provider/not_null_function_test.go
+++ b/internal/provider/not_null_function_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
@@ -220,7 +221,7 @@ output "test" {
 	})
 }
 
-func TestNotNullFunction_falseCases(t *testing.T) {
+func TestNotNullFunction_compoundValidation(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -230,11 +231,78 @@ func TestNotNullFunction_falseCases(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
+variable "ipv4_ipam_pool_id" {
+  default     = null
+  description = "ID of the IPv4 IPAM pool to use for the VPC."
+  type        = string
+}
+
+variable "cidr_block" {
+  default     = null
+  description = "CIDR block for the VPC."
+  type        = string
+
+  validation {
+    condition = provider::assert::cidr(var.cidr_block)
+    error_message = "CIDR block must be a valid CIDR range."
+  }
+
+  validation {
+    condition = anytrue([
+	  provider::assert::not_null(var.cidr_block), 
+	  provider::assert::not_null(var.ipv4_ipam_pool_id)
+	])
+    error_message = "Exactly one of cidr_block or ipv4_ipam_pool_id must be provided."
+  }
+}
+				`,
+				ConfigVariables: config.Variables{
+					"cidr_block": config.StringVariable("10.0.42.0/24"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestNotNullFunction_falseCases(t *testing.T) {
+	t.Parallel()
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion(MinimalRequiredTerraformVersion))),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"wireguard": {
+				Source:            "OJFord/wireguard",
+				VersionConstraint: "0.3.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
 locals {
   object = null
 }
 output "test" {
   value = provider::assert::not_null(local.object)
+}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("test", "false"),
+				),
+			},
+			{
+				Config: `
+resource "wireguard_asymmetric_key" "main" {}
+
+data "wireguard_config_document" "main" {
+  private_key = wireguard_asymmetric_key.main.private_key
+}
+
+output "test" {
+  // .addresses is always null in this configuration
+  value = provider::assert::not_null(data.wireguard_config_document.main.addresses)
 }
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/not_null_function_test.go
+++ b/internal/provider/not_null_function_test.go
@@ -225,39 +225,33 @@ func TestNotNullFunction_compoundValidation(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion(MinimalRequiredTerraformVersion))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))),
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `
-variable "ipv4_ipam_pool_id" {
+variable "example_value_a" {
   default     = null
-  description = "ID of the IPv4 IPAM pool to use for the VPC."
+  description = "Example input A for validation."
   type        = string
 }
-
-variable "cidr_block" {
+variable "example_value_b" {
   default     = null
-  description = "CIDR block for the VPC."
+  description = "Example input B for validation."
   type        = string
-
-  validation {
-    condition     = provider::assert::cidr(var.cidr_block)
-    error_message = "CIDR block must be a valid CIDR range."
-  }
-
   validation {
     condition = anytrue([
-      provider::assert::not_null(var.cidr_block),
-      provider::assert::not_null(var.ipv4_ipam_pool_id)
+      provider::assert::not_null(var.example_value_a),
+      provider::assert::not_null(var.example_value_b)
+
     ])
-    error_message = "Exactly one of cidr_block or ipv4_ipam_pool_id must be provided."
+    error_message = "At least one of example_value_a or example_value_b must be provided."
   }
 }
 				`,
 				ConfigVariables: config.Variables{
-					"cidr_block": config.StringVariable("10.0.42.0/24"),
+					"example_value_b": config.StringVariable("example-format-value"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(),
 			},

--- a/internal/provider/null_function.go
+++ b/internal/provider/null_function.go
@@ -30,7 +30,7 @@ func (r IsNullFunction) Definition(_ context.Context, _ function.DefinitionReque
 		Parameters: []function.Parameter{
 			function.DynamicParameter{
 				AllowNullValue:     true,
-				AllowUnknownValues: true,
+				AllowUnknownValues: false,
 				Description:        "The argument to check",
 				Name:               "argument",
 			},
@@ -47,7 +47,14 @@ func (r IsNullFunction) Run(ctx context.Context, req function.RunRequest, resp *
 		return
 	}
 
-	if argument.UnderlyingValue() == nil {
+	if argument.IsNull() {
+		if err := resp.Result.Set(ctx, true); err == nil {
+			return
+		}
+		return
+	}
+
+	if argument.IsUnderlyingValueNull() {
 		if err := resp.Result.Set(ctx, true); err == nil {
 			return
 		}

--- a/internal/provider/null_function.go
+++ b/internal/provider/null_function.go
@@ -48,16 +48,12 @@ func (r IsNullFunction) Run(ctx context.Context, req function.RunRequest, resp *
 	}
 
 	if argument.IsNull() {
-		if err := resp.Result.Set(ctx, true); err == nil {
-			return
-		}
+		resp.Error = resp.Result.Set(ctx, true)
 		return
 	}
 
 	if argument.IsUnderlyingValueNull() {
-		if err := resp.Result.Set(ctx, true); err == nil {
-			return
-		}
+		resp.Error = resp.Result.Set(ctx, true)
 		return
 	}
 

--- a/internal/provider/null_function_test.go
+++ b/internal/provider/null_function_test.go
@@ -94,15 +94,15 @@ variable "cidr_block" {
   type        = string
 
   validation {
-    condition = provider::assert::cidr(var.cidr_block)
+    condition     = provider::assert::cidr(var.cidr_block)
     error_message = "CIDR block must be a valid CIDR range."
   }
 
   validation {
     condition = anytrue([
-	  !provider::assert::null(var.cidr_block), 
-	  !provider::assert::null(var.ipv4_ipam_pool_id)
-	])
+      !provider::assert::null(var.cidr_block),
+      !provider::assert::null(var.ipv4_ipam_pool_id)
+    ])
     error_message = "Exactly one of cidr_block or ipv4_ipam_pool_id must be provided."
   }
 }

--- a/internal/provider/null_function_test.go
+++ b/internal/provider/null_function_test.go
@@ -76,39 +76,34 @@ func TestNullFunction_compoundValidation(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion(MinimalRequiredTerraformVersion))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))),
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `
-variable "ipv4_ipam_pool_id" {
+variable "example_value_a" {
   default     = null
-  description = "ID of the IPv4 IPAM pool to use for the VPC."
+  description = "Example option A for testing null validation."
   type        = string
 }
 
-variable "cidr_block" {
+variable "example_value_b" {
   default     = null
-  description = "CIDR block for the VPC."
+  description = "Example option B for testing null validation."
   type        = string
 
   validation {
-    condition     = provider::assert::cidr(var.cidr_block)
-    error_message = "CIDR block must be a valid CIDR range."
-  }
-
-  validation {
     condition = anytrue([
-      !provider::assert::null(var.cidr_block),
-      !provider::assert::null(var.ipv4_ipam_pool_id)
+      !provider::assert::null(var.example_value_a),
+      !provider::assert::null(var.example_value_b)
     ])
-    error_message = "Exactly one of cidr_block or ipv4_ipam_pool_id must be provided."
+    error_message = "Exactly one of example_value_a or example_value_b must be provided."
   }
 }
 				`,
 				ConfigVariables: config.Variables{
-					"cidr_block": config.StringVariable("10.0.42.0/24"),
+					"example_value_b": config.StringVariable("example-value"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(),
 			},


### PR DESCRIPTION
Fixes #76 
Fixes #71 

* Currently, `null` checks whether the DynamicValue represents a literal `null` with no known type. This behavior conflicted with cross-object validation, where the type is known, and the underlying value needs to be checked to see if it evaluates to null. 9725ed fixes this.
* Similarly, for `not_null`, we’re enabling cross-object validation by first determining if we’re dealing with a literal `null` value. If not, the underlying value is then checked to confirm whether it is `null` or not.