### PR TITLE
scope cross variable validation to 1.10.0

### DIFF
--- a/internal/provider/not_null_function_test.go
+++ b/internal/provider/not_null_function_test.go
@@ -225,7 +225,7 @@ func TestNotNullFunction_compoundValidation(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.10.0"))),
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/null_function_test.go
+++ b/internal/provider/null_function_test.go
@@ -76,7 +76,7 @@ func TestNullFunction_compoundValidation(t *testing.T) {
 	t.Parallel()
 	resource.UnitTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.2.0"))),
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.10.0"))),
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Terraform 1.10.0 introduced cross-variable validation, and this pull request resolves test failures in the GitHub Actions matrix for older Terraform versions attempting to run these cross variable validation tests.